### PR TITLE
Update article 2+3 demo README.md

### DIFF
--- a/article-02+03/README.md
+++ b/article-02+03/README.md
@@ -2,7 +2,7 @@
 
 This directory contains demo code for DelphiDabbler's articles "[How to store files inside an executable program](https://delphidabbler.com/articles/article-2)" and "[How to read data embedded in your program's resources](https://delphidabbler.com/articles/article-3)".
 
-The demo was not originally developed under version control. It's last update was on 30 September 2001. The code was added to the [`delphidabbler/article-demos`](https://github.com/delphidabbler/article-demos) GitHub repository on 24 April 2002.
+The demo was not originally developed under version control. It's last update was on 30 September 2001. The code was added to the [`delphidabbler/article-demos`](https://github.com/delphidabbler/article-demos) GitHub repository on 24 April 2022.
 
 ## Bug Reports
 


### PR DESCRIPTION
Fix error in date demo added to Git from 2002 to 2022.